### PR TITLE
[feat] 승부 기록 API 수정

### DIFF
--- a/src/main/java/com/universe/uni/controller/ShortGameController.java
+++ b/src/main/java/com/universe/uni/controller/ShortGameController.java
@@ -40,7 +40,13 @@ public class ShortGameController {
 	public GameReportResponseDto enterGameResult(
 		@PathVariable final Long roundGameId,
 		@RequestBody @Valid final EnterGameResultDto enterGameResultDto) {
-		return gameService.updateGameScore(roundGameId, enterGameResultDto.getResult());
+		return gameService.updateGameResult(roundGameId, enterGameResultDto.getResult());
+	}
+
+	@PostMapping("/{roundGameId}")
+	@ResponseStatus(HttpStatus.OK)
+	public GameReportResponseDto checkFinalGameResult(@PathVariable final Long roundGameId) {
+		return gameService.updateFinalGameResult(roundGameId);
 	}
 
 	@GetMapping("/{roundGameId}")

--- a/src/main/java/com/universe/uni/dto/response/GameReportResponseDto.java
+++ b/src/main/java/com/universe/uni/dto/response/GameReportResponseDto.java
@@ -1,5 +1,6 @@
 package com.universe.uni.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.universe.uni.domain.entity.RoundMission;
 import com.universe.uni.dto.RoundMissionDto;
 
@@ -8,6 +9,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class GameReportResponseDto {
 	private RoundMissionDto myRoundMission;
 	private RoundMissionDto partnerRoundMission;

--- a/src/main/java/com/universe/uni/dto/response/MissionCategoryDto.java
+++ b/src/main/java/com/universe/uni/dto/response/MissionCategoryDto.java
@@ -11,7 +11,9 @@ public class MissionCategoryDto {
 	private final Long id;
 	private final String title;
 	private final String description;
+	private final String rule;
 	private final String tip;
+	private final String example;
 	private final String image;
 	private final int level;
 	private final int expectedTime;
@@ -22,7 +24,9 @@ public class MissionCategoryDto {
 		this.id = missionCategory.getId();
 		this.title = missionCategory.getTitle();
 		this.description = missionCategory.getDescription();
+		this.rule = missionCategory.getRule();
 		this.tip = missionCategory.getTip();
+		this.example = missionCategory.getExample();
 		this.image = missionCategory.getImage();
 		this.level = missionCategory.getLevel();
 		this.expectedTime = missionCategory.getExpectedTime();

--- a/src/main/java/com/universe/uni/dto/response/MissionCategoryDto.java
+++ b/src/main/java/com/universe/uni/dto/response/MissionCategoryDto.java
@@ -1,5 +1,6 @@
 package com.universe.uni.dto.response;
 
+import com.universe.uni.domain.MissionTool;
 import com.universe.uni.domain.MissionType;
 import com.universe.uni.domain.entity.MissionCategory;
 
@@ -15,6 +16,7 @@ public class MissionCategoryDto {
 	private final int level;
 	private final int expectedTime;
 	private final MissionType missionType;
+	private final MissionTool missionTool;
 
 	public MissionCategoryDto(MissionCategory missionCategory) {
 		this.id = missionCategory.getId();
@@ -25,5 +27,6 @@ public class MissionCategoryDto {
 		this.level = missionCategory.getLevel();
 		this.expectedTime = missionCategory.getExpectedTime();
 		this.missionType = missionCategory.getMissionType();
+		this.missionTool = missionCategory.getMissionTool();
 	}
 }

--- a/src/main/java/com/universe/uni/exception/dto/ErrorType.java
+++ b/src/main/java/com/universe/uni/exception/dto/ErrorType.java
@@ -24,6 +24,8 @@ public enum ErrorType {
 	COUPLE_NOT_EXISTENT(HttpStatus.BAD_REQUEST, "UE1006", "존재하지 않는 커플 id 입니다"),
 	INVALID_INVITE_CODE(HttpStatus.BAD_REQUEST, "UE1007", "올바르지 않은 초대 코드입니다."),
 	TOKEN_VALUE_NOT_EXIST(HttpStatus.BAD_REQUEST, "UE1008", "토큰 값이 존재하지 않습니다."),
+	PARTNER_RESULT_NOT_ENTERED(HttpStatus.BAD_REQUEST, "UE1009",
+		"상대방이 아직 결과를 입력하지 않았습니다."),
 
 	/**
 	 * 401 Unauthorized

--- a/src/main/java/com/universe/uni/service/GameService.java
+++ b/src/main/java/com/universe/uni/service/GameService.java
@@ -3,9 +3,7 @@ package com.universe.uni.service;
 import static com.universe.uni.domain.GameResult.DRAW;
 import static com.universe.uni.domain.GameResult.LOSE;
 import static com.universe.uni.domain.GameResult.WIN;
-import static com.universe.uni.exception.dto.ErrorType.ALREADY_GAME_CREATED;
-import static com.universe.uni.exception.dto.ErrorType.ALREADY_GAME_DONE;
-import static com.universe.uni.exception.dto.ErrorType.NOT_FOUND_ROUND_MISSION;
+import static com.universe.uni.exception.dto.ErrorType.*;
 
 import com.universe.uni.domain.GameResult;
 import com.universe.uni.domain.GameType;
@@ -134,27 +132,33 @@ public class GameService {
     }
 
     @Transactional
-    public GameReportResponseDto updateGameScore(Long roundGameId, Boolean result) {
+    public GameReportResponseDto updateGameResult(Long roundGameId, Boolean result) {
+        User user = userUtil.getCurrentUser();
+        RoundGame roundGame = getRoundGameById(roundGameId);
+        RoundMission myRoundMission = getRoundMissionByRoundGameAndUser(roundGame, user);
 
+        updateGameResultWithTimeRecord(myRoundMission, result);
+
+        return GameReportResponseDto.of(myRoundMission);
+    }
+
+    @Transactional
+    public GameReportResponseDto updateFinalGameResult(Long roundGameId) {
         User user = userUtil.getCurrentUser();
         RoundGame roundGame = getRoundGameById(roundGameId);
         RoundMission myRoundMission = getRoundMissionByRoundGameAndUser(roundGame, user);
         RoundMission partnerRoundMission = getPartnerRoundMission(roundGame, user);
 
-        updateGameResultWithTimeRecord(myRoundMission, result);
-
-        if (isResultEntered(partnerRoundMission)) {
-            User winner = decideFinalGameScore(myRoundMission, partnerRoundMission);
-            finishGame(roundGame);
-            updateGameHistory(myRoundMission, partnerRoundMission);
-            wishCouponService.giveWishCouponToWinner(roundGame.getGame(), winner);
-            return GameReportResponseDto.of(myRoundMission, partnerRoundMission);
-        } else {
-            if (result) {
-                myRoundMission.updateFinalResult(WIN);
-            }
-            return GameReportResponseDto.of(myRoundMission);
+        if(!isResultEntered(partnerRoundMission)) {
+            throw new BadRequestException(PARTNER_RESULT_NOT_ENTERED);
         }
+
+        User winner = decideFinalGameScore(myRoundMission, partnerRoundMission);
+        finishGame(roundGame);
+        updateGameHistory(myRoundMission, partnerRoundMission);
+        wishCouponService.giveWishCouponToWinner(roundGame.getGame(), winner);
+
+        return GameReportResponseDto.of(myRoundMission, partnerRoundMission);
     }
 
     private void finishGame(RoundGame roundGame) {

--- a/src/main/java/com/universe/uni/service/GameService.java
+++ b/src/main/java/com/universe/uni/service/GameService.java
@@ -260,9 +260,8 @@ public class GameService {
 
         //verifyIsOngoingGame(roundGame);
         RoundMission myRoundMission = getRoundMissionByRoundGameAndUser(roundGame, user);
-        RoundMission partnerRoundMission = getPartnerRoundMission(roundGame, user);
 
-        return GameReportResponseDto.of(myRoundMission, partnerRoundMission);
+        return GameReportResponseDto.of(myRoundMission);
     }
 
     private void verifyIsOngoingGame(RoundGame roundGame) {


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #114

## 🔑 Key Changes

1. 승부 기록 로직 수정(`승부 결과 입력`&`최종 결과 확인하기`로 분리)
2. 최종 결과 확인하기 API 구현하기
3. 추가된 컬럼들 (rule, example, missionTool) dto에 추가

## 📢 To Reviewers
- 
