### PR TITLE
[Feat] 게임 생성 시 동시성 문제 해결

### DIFF
--- a/src/main/java/com/universe/uni/controller/ControllerExceptionAdvice.java
+++ b/src/main/java/com/universe/uni/controller/ControllerExceptionAdvice.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -128,6 +129,12 @@ public class ControllerExceptionAdvice extends ResponseEntityExceptionHandler {
         sendSentryEvent(exception, request);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.businessErrorOf(ErrorType.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ErrorResponse> handleOptimisticLock(ObjectOptimisticLockingFailureException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.businessErrorOf(ErrorType.ALREADY_GAME_CREATED));
     }
 
     private void sendSentryEvent(

--- a/src/main/java/com/universe/uni/controller/ControllerExceptionAdvice.java
+++ b/src/main/java/com/universe/uni/controller/ControllerExceptionAdvice.java
@@ -131,12 +131,6 @@ public class ControllerExceptionAdvice extends ResponseEntityExceptionHandler {
                 .body(ErrorResponse.businessErrorOf(ErrorType.INTERNAL_SERVER_ERROR));
     }
 
-    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
-    public ResponseEntity<ErrorResponse> handleOptimisticLock(ObjectOptimisticLockingFailureException exception) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ErrorResponse.businessErrorOf(ErrorType.ALREADY_GAME_CREATED));
-    }
-
     private void sendSentryEvent(
             Exception exception,
             WebRequest request

--- a/src/main/java/com/universe/uni/domain/entity/Couple.java
+++ b/src/main/java/com/universe/uni/domain/entity/Couple.java
@@ -8,6 +8,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Version;
 
 import org.hibernate.annotations.ColumnDefault;
 
@@ -28,6 +29,9 @@ public class Couple {
 	@Column(name = "couple_id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@Version
+	private long version;
 
 	@Column(name = "start_date", nullable = false)
 	private LocalDate startDate;

--- a/src/main/java/com/universe/uni/repository/CoupleRepository.java
+++ b/src/main/java/com/universe/uni/repository/CoupleRepository.java
@@ -2,10 +2,16 @@ package com.universe.uni.repository;
 
 import java.util.Optional;
 
+import javax.persistence.LockModeType;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import com.universe.uni.domain.entity.Couple;
 
 public interface CoupleRepository extends JpaRepository<Couple, Long> {
 	Optional<Couple> findByInviteCode(String inviteCode);
+
+	@Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+	Optional<Couple> findWithOptimisticForceIncrementById(Long coupleId);
 }

--- a/src/main/java/com/universe/uni/service/GameService.java
+++ b/src/main/java/com/universe/uni/service/GameService.java
@@ -21,6 +21,7 @@ import com.universe.uni.dto.response.CreateShortGameResponseDto;
 import com.universe.uni.dto.response.GameReportResponseDto;
 import com.universe.uni.exception.BadRequestException;
 import com.universe.uni.exception.NotFoundException;
+import com.universe.uni.repository.CoupleRepository;
 import com.universe.uni.repository.GameRepository;
 import com.universe.uni.repository.RoundGameRepository;
 import com.universe.uni.repository.RoundMissionRepository;
@@ -45,6 +46,7 @@ public class GameService {
     private final RoundGameRepository roundGameRepository;
     private final RoundMissionRepository roundMissionRepository;
     private final UserRepository userRepository;
+    private final CoupleRepository coupleRepository;
     private final UserGameHistoryRepository userGameHistoryRepository;
     private final MissionService missionService;
     private final WishCouponService wishCouponService;
@@ -59,6 +61,8 @@ public class GameService {
         final User user = userUtil.getCurrentUser();
         final Couple couple = user.getCouple();
 
+        getLockedCoupleById(couple.getId());
+
         //한판승부 생성
         ShortGame shortGame = createShortGameBy(couple);
         //roundGame 생성
@@ -72,6 +76,11 @@ public class GameService {
         RoundMission myRoundMission = getRoundMissionByRoundGameAndUser(roundGame, user);
 
         return CreateShortGameResponseDto.of(shortGame, roundGame.getId(), myRoundMission);
+    }
+
+    private void getLockedCoupleById(Long coupleId) {
+        coupleRepository.findWithOptimisticForceIncrementById(coupleId)
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_COUPLE));
     }
 
     private ShortGame createShortGameBy(Couple couple) {


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #118

## 🔑 Key Changes

1. Couple이 아닌 두 유저의 경우 동시에 요청이 와도 동시에 처리 되어야 한다.
2. Couple인 두 유저의 경우 동시에 요청이 오면 커플에 대한 게임이 2개 생성되지 않도록 처리해야 한다.

## 📢 To Reviewers
- 
