### PR TITLE
커플 연결 관련 수정

### DIFF
--- a/src/main/java/com/universe/uni/controller/CoupleController.java
+++ b/src/main/java/com/universe/uni/controller/CoupleController.java
@@ -2,8 +2,10 @@ package com.universe.uni.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -57,4 +59,11 @@ public class CoupleController {
 	) {
 		return coupleService.checkConnection(userId);
 	}
+
+	@DeleteMapping("")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void disconnectCouple(@AuthenticationPrincipal Long userId) {
+		coupleService.disconnectCouple(userId);
+	}
+
 }

--- a/src/main/java/com/universe/uni/exception/dto/ErrorType.java
+++ b/src/main/java/com/universe/uni/exception/dto/ErrorType.java
@@ -65,6 +65,8 @@ public enum ErrorType {
 	 */
 	USER_ALREADY_EXISTS_EXCEPTION(HttpStatus.CONFLICT, "UE10001",
 		"이미 존재하는 유저에 대한 생성에 대한 경우입니다."),
+	COUPLE_ALREADY_CONNECTED(HttpStatus.CONFLICT, "UE10002",
+		"이미 커플이 연결된 초대코드입니다."),
 
 	/**
 	 * 415 Unsupported Media Type

--- a/src/main/java/com/universe/uni/repository/UserRepository.java
+++ b/src/main/java/com/universe/uni/repository/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	User findByCoupleIdAndIdNot(Long coupleId, Long userId);
 
 	User findByCoupleId(Long coupleId);
+
+	int countByCoupleId(Long coupleId);
 }

--- a/src/main/java/com/universe/uni/service/CoupleService.java
+++ b/src/main/java/com/universe/uni/service/CoupleService.java
@@ -65,14 +65,14 @@ public class CoupleService implements CoupleServiceContract {
 	public void joinCouple(Long userId, String inviteCode) {
 		final Couple couple = coupleRepository.findByInviteCode(inviteCode)
 			.orElseThrow(() -> new BadRequestException(ErrorType.INVALID_INVITE_CODE));
-		validateIfCoupleConnected(couple);
+		validateCoupleConnected(couple);
 		final User user = userRepository.findById(userId)
 			.orElseThrow(() -> new BadRequestException(ErrorType.USER_NOT_EXISTENT));
 		user.connectCouple(couple);
 
 	}
 
-	private void validateIfCoupleConnected(Couple couple) {
+	private void validateCoupleConnected(Couple couple) {
 		if(userRepository.countByCoupleId(couple.getId()) >= 2) {
 			throw new ConflictException(COUPLE_ALREADY_CONNECTED);
 		}

--- a/src/main/java/com/universe/uni/service/CoupleService.java
+++ b/src/main/java/com/universe/uni/service/CoupleService.java
@@ -106,4 +106,13 @@ public class CoupleService implements CoupleServiceContract {
 	public void deleteCouple(Long coupleId) {
 		coupleRepository.deleteById(coupleId);
 	}
+
+	@Override
+	@Transactional
+	public void disconnectCouple(Long userId) {
+		final User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BadRequestException(ErrorType.USER_NOT_EXISTENT));
+		final Couple couple = user.getCouple();
+		deleteCouple(couple.getId());
+	}
 }

--- a/src/main/java/com/universe/uni/service/CoupleService.java
+++ b/src/main/java/com/universe/uni/service/CoupleService.java
@@ -1,5 +1,7 @@
 package com.universe.uni.service;
 
+import static com.universe.uni.exception.dto.ErrorType.*;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -15,11 +17,13 @@ import com.universe.uni.domain.entity.User;
 import com.universe.uni.dto.response.CoupleConnectionResponseDto;
 import com.universe.uni.dto.response.CoupleDto;
 import com.universe.uni.exception.BadRequestException;
+import com.universe.uni.exception.ConflictException;
 import com.universe.uni.exception.dto.ErrorType;
 import com.universe.uni.mapper.CoupleMapper;
 import com.universe.uni.repository.CoupleRepository;
 import com.universe.uni.repository.UserRepository;
 
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -61,10 +65,17 @@ public class CoupleService implements CoupleServiceContract {
 	public void joinCouple(Long userId, String inviteCode) {
 		final Couple couple = coupleRepository.findByInviteCode(inviteCode)
 			.orElseThrow(() -> new BadRequestException(ErrorType.INVALID_INVITE_CODE));
+		validateIfCoupleConnected(couple);
 		final User user = userRepository.findById(userId)
 			.orElseThrow(() -> new BadRequestException(ErrorType.USER_NOT_EXISTENT));
 		user.connectCouple(couple);
 
+	}
+
+	private void validateIfCoupleConnected(Couple couple) {
+		if(userRepository.countByCoupleId(couple.getId()) >= 2) {
+			throw new ConflictException(COUPLE_ALREADY_CONNECTED);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/universe/uni/service/CoupleServiceContract.java
+++ b/src/main/java/com/universe/uni/service/CoupleServiceContract.java
@@ -25,4 +25,7 @@ public interface CoupleServiceContract {
 
 	@Transactional
 	void deleteCouple(Long coupleId);
+
+	@Transactional
+	void disconnectCouple(Long userId);
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #126 

## 🔑 Key Changes

1. 커플 코드 입력 시 이미 커플이 성사된 경우라면 에러 처리
2. 실수로 되어버린 경우를 대비해 커플 끊기 API추가

## 📢 To Reviewers
- 현재 한 user가 커플을 끊을 경우 다른 user의 couple도 null값이 된다. 상대방이 커플 끊을 경우 남겨진 사람은 어떻게 해야 할 지에 대한 플로우에 따라 처리가 필요할 거 같다.
