### PR TITLE
[Feat] 최종승부결과 확인하기 관련 API 수정

### DIFF
--- a/src/main/java/com/universe/uni/domain/entity/RoundMission.java
+++ b/src/main/java/com/universe/uni/domain/entity/RoundMission.java
@@ -73,4 +73,8 @@ public class RoundMission {
 	public void updateFinalResult(GameResult finalResult) {
 		this.finalResult = finalResult;
 	}
+
+	public LocalDateTime getUpdatedAt() {
+		return updatedAt;
+	}
 }

--- a/src/main/java/com/universe/uni/repository/UserGameHistoryRepository.java
+++ b/src/main/java/com/universe/uni/repository/UserGameHistoryRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.universe.uni.domain.entity.Game;
 import com.universe.uni.domain.entity.User;
 import com.universe.uni.domain.entity.UserGameHistory;
 
@@ -12,4 +13,6 @@ public interface UserGameHistoryRepository extends JpaRepository<UserGameHistory
 	List<UserGameHistory> findByUserId(Long userId);
 
 	List<UserGameHistory> findByUser(User user);
+
+	boolean existsByGame(Game game);
 }

--- a/src/main/java/com/universe/uni/service/GameService.java
+++ b/src/main/java/com/universe/uni/service/GameService.java
@@ -189,9 +189,12 @@ public class GameService {
         }
 
         User winner = decideFinalGameScore(myRoundMission, partnerRoundMission);
-        finishGame(roundGame);
-        updateGameHistory(myRoundMission, partnerRoundMission);
-        wishCouponService.giveWishCouponToWinner(roundGame.getGame(), winner);
+
+        if(!userGameHistoryRepository.existsByGame(roundGame.getGame())) {
+            finishGame(roundGame);
+            updateGameHistory(myRoundMission, partnerRoundMission);
+            wishCouponService.giveWishCouponToWinner(roundGame.getGame(), winner);
+        }
 
         return GameReportResponseDto.of(myRoundMission, partnerRoundMission);
     }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #135 

## 🔑 Key Changes

1. 둘 다 승리 눌렀을 경우 시간 비교해서 winner 설정해주기
2. 승부 히스토리 추가 로직 수정

## 📢 To Reviewers
- 
